### PR TITLE
add pre-commit for Pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+-   repo: https://github.com/pre-commit/mirrors-pylint
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    -   id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
 -   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: ''  # Use the sha / tag you want to point at
+    rev: v1.9.1  # Use the sha / tag you want to point at
     hooks:
     -   id: pylint

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,5 @@
 # -*- mode: ruby -*-
+
 # vi: set ft=ruby :
 
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
@@ -62,6 +63,7 @@ Vagrant.configure(2) do |config|
     # Install app dependencies
     cd /vagrant
     pip3 install -r requirements.txt
+	pre-commit install
   SHELL
 
   ######################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-API==1.1
 Flask-SQLAlchemy==2.4.1
 psycopg2-binary==2.8.3
 pymysql==0.9.3
+pre-commit==1.18.3
 
 # Testing
 nose==1.3.7
@@ -11,3 +12,4 @@ pinocchio==0.4.2
 factory-boy==2.12.0
 coverage==4.5.4
 pylint>=2.4.1
+pre-commit==1.18.3


### PR DESCRIPTION
When you commit a Python file it will run Pylint and gives a score like this
<img width="565" alt="Screen Shot 2019-10-08 at 3 42 42 PM" src="https://user-images.githubusercontent.com/8155532/66436828-2ac08f00-e9f6-11e9-9716-d5402154ba33.png">
Added to vagrant file.
Run "pre-commit install" if not working