### PR TITLE
Fix: Remove customer_id from primary keys

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -60,7 +60,7 @@ class Wishlist(db.Model):
 
     # Table Schema
     id = db.Column(db.Integer, primary_key=True)
-    customer_id = db.Column(db.Integer, primary_key=True)
+    customer_id = db.Column(db.Integer)
     name = db.Column(db.String(50))
 
     def __repr__(self):


### PR DESCRIPTION
In my previous PR, I made a mistake and made customer_id as a primary key. This is incorrect. Hence fixing it here