### PR TITLE
Adding fakes for product and shopcarts services

### DIFF
--- a/fakes/products.py
+++ b/fakes/products.py
@@ -1,0 +1,45 @@
+"""
+Fakes for Product service
+
+"""
+
+import logging
+import sys
+from flask import Flask, jsonify, make_response
+from flask_api import status    # HTTP Status Codes
+
+APP = Flask(__name__)
+
+if not APP.debug:
+    print('Setting up logging...')
+    # Set up default logging for submodules to use STDOUT
+    # datefmt='%m/%d/%Y %I:%M:%S %p'
+    FMT = '[%(asctime)s] %(levelname)s in %(module)s: %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FMT)
+    # Make a new log handler that uses STDOUT
+    HANDLER = logging.StreamHandler(sys.stdout)
+    HANDLER.setFormatter(logging.Formatter(FMT))
+    HANDLER.setLevel(logging.INFO)
+    # Remove the Flask default handlers and use our own
+    HANDLER_LIST = list(APP.logger.handlers)
+    for log_handler in HANDLER_LIST:
+        APP.logger.removeHandler(log_handler)
+    APP.logger.addHandler(HANDLER)
+    APP.logger.setLevel(logging.INFO)
+    APP.logger.propagate = False
+    APP.logger.info('Logging handler established')
+
+@APP.route('/products/<int:product_id>', methods=['GET'])
+def get_product_details(product_id):
+    """ Fake route for getting product details """
+    APP.logger.info('Request to get product details of \'%s\'' % product_id)
+    return make_response(jsonify({
+        "id": product_id,
+        "name": "Macbook",
+        "stock": 10,
+        "price": 1799.0,
+        "description": "This product is very powerful",
+        "category": "Electronics"
+    }), status.HTTP_200_OK)
+
+APP.run(host='0.0.0.0', port=5001)

--- a/fakes/shopcarts.py
+++ b/fakes/shopcarts.py
@@ -1,0 +1,38 @@
+"""
+Fakes for ShopCarts service
+
+"""
+
+import logging
+import sys
+from flask import Flask, jsonify, make_response
+from flask_api import status    # HTTP Status Codes
+
+APP = Flask(__name__)
+
+if not APP.debug:
+    print('Setting up logging...')
+    # Set up default logging for submodules to use STDOUT
+    # datefmt='%m/%d/%Y %I:%M:%S %p'
+    FMT = '[%(asctime)s] %(levelname)s in %(module)s: %(message)s'
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format=FMT)
+    # Make a new log handler that uses STDOUT
+    HANDLER = logging.StreamHandler(sys.stdout)
+    HANDLER.setFormatter(logging.Formatter(FMT))
+    HANDLER.setLevel(logging.INFO)
+    # Remove the Flask default handlers and use our own
+    HANDLER_LIST = list(APP.logger.handlers)
+    for log_handler in HANDLER_LIST:
+        APP.logger.removeHandler(log_handler)
+    APP.logger.addHandler(HANDLER)
+    APP.logger.setLevel(logging.INFO)
+    APP.logger.propagate = False
+    APP.logger.info('Logging handler established')
+
+@APP.route('/shopcarts/<int:customer_id>', methods=['POST'])
+def add_to_shopcart(customer_id):
+    """ Fake route for adding item to shopcarts """
+    APP.logger.info('Request to add product to shop cart of customer \'%s\'' % customer_id)
+    return make_response(jsonify({}), status.HTTP_201_CREATED)
+
+APP.run(host='0.0.0.0', port=5002)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ psycopg2-binary==2.8.3
 pymysql==0.9.3
 ibm_db==3.0.1
 ibm_db_sa==0.3.5
+requests==2.7.0
 
 # Testing
 nose==1.3.7

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -695,7 +695,7 @@ class TestWishlistServer(unittest.TestCase):
         resp = self.app.put('/wishlists/1/items/1/add-to-cart')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_add_to_cart_wishlist_product_not_exist(self):
+    def test_add_to_cart_product_not_exist(self):
         """ Test Add to cart when wishlist product doesn't exits """
         created_wishlist = Wishlist(customer_id=1, name="name")
         created_wishlist.save()
@@ -729,14 +729,14 @@ class TestWishlistServer(unittest.TestCase):
 
     @patch('service.models.Product._get_product_details')
     def test_mock_add_to_cart_product_404(self, bad_request_mock):
-        """ Test Add to cart when Product not found """
+        """ Test Add to cart when Product in Wishlist but not in Products """
         created_wishlist = Wishlist(customer_id=1, name="name")
         created_wishlist.save()
         created_wishlist_product = WishlistProduct(wishlist_id=created_wishlist.id,
                                     product_id=2, product_name='macbook')
         created_wishlist_product.save()
         bad_request_mock.return_value = MagicMock(status_code=404)
-        resp = self.app.put('/wishlists/1/items/1/add-to-cart')
+        resp = self.app.put('/wishlists/1/items/2/add-to-cart')
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     @patch('service.models.Product._get_product_details')


### PR DESCRIPTION
I have fixed errors related to undefined variable names when calling the other services. The way I've implemented right now is by creating fake services defined in the `fakes` directory. Before running the application, we need to run the two services in separate SSH sessions.

```cd /vagrant/fakes```
```python3 products.py```

```cd /vagrant/fakes```
```python3 shopcarts.py```

Once both services are running, we can then run our application as:
```FLASK_APP=service:app PRODUCT_SERV_URL=http://127.0.0.1:5001 SHOPCART_SERV_URL=http://127.0.0.1:5002 flask run -h 0.0.0.0```

The environment variables have been added because we can easily invoke the cloud deployed versions of the Products and ShopCarts services.

```
Name                  Stmts   Miss  Cover
-----------------------------------------
service/__init__.py      23      3    87%
service/models.py       160      3    98%
service/service.py      189      0   100%
-----------------------------------------
TOTAL                   372      6    98%
----------------------------------------------------------------------
Ran 76 tests in 68.761s

OK
```