### PR TITLE
Add feature flag to allow disabling the reset endpoint in prod

### DIFF
--- a/service/__init__.py
+++ b/service/__init__.py
@@ -26,6 +26,7 @@ from flask import Flask
 
 # Get configuration from environment
 DATABASE_URI = os.getenv('DATABASE_URI', 'sqlite:////tmp/test.db')
+DISABLE_RESET_ENDPOINT = os.getenv('DISABLE_RESET_ENDPOINT', '0') in ['True', 'true', '1']
 
 # Create Flask application
 app = Flask(__name__)
@@ -33,6 +34,7 @@ app = Flask(__name__)
 app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URI
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['PROPAGATE_EXCEPTIONS'] = True
+app.config['DISABLE_RESET_ENDPOINT'] = DISABLE_RESET_ENDPOINT
 
 # Import the rutes After the Flask app is created
 from service import service, models

--- a/service/service.py
+++ b/service/service.py
@@ -151,12 +151,13 @@ def delete_wishlists(wishlist_id):
 ######################################################################
 # DELETE ALL WISHLIST DATA (for testing only)
 ######################################################################
-@app.route('/wishlists/reset', methods=['DELETE'])
-def wishlists_reset():
-    """ Removes all wishlits and Products from the database """
-    DatabaseConnection.reset_db()
-    app.logger.info('Request to remove all wishlists from database')
-    return make_response('', status.HTTP_204_NO_CONTENT)
+if not app.config['DISABLE_RESET_ENDPOINT']:
+    @app.route('/wishlists/reset', methods=['DELETE'])
+    def wishlists_reset():
+        """ Removes all wishlits and Products from the database """
+        DatabaseConnection.reset_db()
+        app.logger.info('Request to remove all wishlists from database')
+        return make_response('', status.HTTP_204_NO_CONTENT)
 
 ######################################################################
 # RENAME WISHLIST


### PR DESCRIPTION
Adding a feature flag to disable the reset database endpoint in production. We can test this by setting the environment variable `DISABLE_RESET_ENDPOINT` to `True`, `true` or `1`.

This flag will not be set in local and staging environments as we run BDD tests on them. We only set this in the production version of our application where we do not wish to allow users to reset our database.