### PR TITLE
Adding Flask-RESTPlus for Create Wishlist API

### DIFF
--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -67,7 +67,7 @@ def table_contains(element, wishlist_name, customer_id):
 @given('The service is running')
 def step_impl(context):
     """ Make a call to the base URL """
-    context.driver.get(context.base_url)
+    context.driver.get(context.base_url + '/home')
     element = WebDriverWait(context.driver, WAIT_SECONDS).until(
         expected_conditions.presence_of_element_located((By.XPATH, '/html/body/div/div[1]/h1'))
     )
@@ -108,7 +108,7 @@ def step_impl(context):
 @when('I visit the "home page"')
 def step_impl(context):
     """ Make a call to the base URL """
-    context.driver.get(context.base_url)
+    context.driver.get(context.base_url + '/home')
     element = WebDriverWait(context.driver, WAIT_SECONDS).until(
         expected_conditions.text_to_be_present_in_element((By.XPATH, '/html/body/div/div[1]/h1'), 'Wishlist REST API Service')
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ psycopg2-binary==2.8.3
 ibm_db==3.0.1
 ibm_db_sa==0.3.5
 requests==2.20.0
+flask-restplus==0.13.0
 
 # Testing
 nose==1.3.7

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -35,6 +35,7 @@ app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URI
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 app.config['PROPAGATE_EXCEPTIONS'] = True
 app.config['DISABLE_RESET_ENDPOINT'] = DISABLE_RESET_ENDPOINT
+app.config['ERROR_404_HELP'] = False
 
 # Import the rutes After the Flask app is created
 from service import service, models

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -65,7 +65,7 @@ class TestWishlistServer(unittest.TestCase):
 
     def test_home(self):
         """ Test the Home Page """
-        resp = self.app.get('/')
+        resp = self.app.get('/home')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_create_wishlist(self):


### PR DESCRIPTION
This PR Refactors the create wishlist API using Flask-RESTPlus. As a result of the refactoring, we get swagger docs for free. They are accessible at `/apidocs/index.html`.

There is one undesired change that I had to make:
The home page of the application is now at `/home`. There seems to be a bug in Flask-RESTPlus which makes it really weird to have the home page `/` display anything. The scenarios are:

1. If we set the prefix of the api to `/`, and set the create and read api's to be annotated with `@api.route('wishlists')` then the `/` doesn't show the homepage. [Current implementation]
2. If we set the prefix of the api to `/wishlists`, and set the create and read api's to be annotated with `@api.route('')` then the `/` shows the homepage, the `post` function for the create wishlist works, but the `get` function of read wishlists stops working. [I have no clue why this happens. Didn't debug into `Flask-RESTPlus`'s implementation.
3. If we set the prefix of the api to `/wishlist`, and set the create and read api's to be annotated with `@api.route('s')` then everything works as expected. I didn't implement it this way since it messes up the readability of the code.